### PR TITLE
Fix: update release configuration to disable draft releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,6 @@ jobs:
             - **`.AppImage`** - Portable, works on most distributions. Make executable with `chmod +x` and run directly.
             - **`.deb`** - For Debian, Ubuntu, and derivatives. Install with `sudo dpkg -i <file>.deb`.
             - **`.rpm`** - For Fedora, RHEL, and derivatives. Install with `sudo rpm -i <file>.rpm`.
-          releaseDraft: true
+          releaseDraft: false
           prerelease: false
           includeUpdaterJson: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release process to publish releases directly instead of saving them as drafts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->