### PR TITLE
Refactor: merge JavaScript test and coverage CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,33 +65,6 @@ jobs:
       - name: Run type check
         run: pnpm run check-types
 
-  test-js:
-    name: JavaScript Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Cache Turbo
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ runner.os }}-
-
-      - name: Run tests
-        run: pnpm run test
-
   rust-checks:
     name: Rust Checks
     runs-on: ubuntu-latest
@@ -149,8 +122,8 @@ jobs:
           RUSTC_WRAPPER: sccache
           RUSTFLAGS: "-C linker=clang -C link-arg=-fuse-ld=mold"
 
-  js-coverage:
-    name: JavaScript Coverage
+  test-js:
+    name: JavaScript Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -139,7 +139,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "app"
-version = "0.2.5"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "headless_chrome",


### PR DESCRIPTION
## Summary
- Consolidate duplicate `test-js` and `js-coverage` jobs into a single job
- Tests now run once with coverage enforcement (80% threshold)
- Reduces CI redundancy and compute costs

## Test plan
- [ ] Verify CI runs with only one JavaScript test job
- [ ] Confirm coverage threshold (80%) is still enforced
- [ ] Check all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined CI workflow by consolidating JavaScript test and coverage jobs into a single unified job, reducing workflow redundancy and improving efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->