### PR TITLE
Add retailer URLs to product create dialog

### DIFF
--- a/apps/desktop/src/__tests__/unit/components/product-form-dialog.test.tsx
+++ b/apps/desktop/src/__tests__/unit/components/product-form-dialog.test.tsx
@@ -240,10 +240,10 @@ describe("ProductFormDialog", () => {
 				/>,
 			);
 
-			expect(screen.getByTestId("retailer-url-0")).toHaveValue(
+			expect(screen.getByLabelText("Retailer 1 URL")).toHaveValue(
 				"https://example.com",
 			);
-			expect(screen.getByTestId("retailer-label-0")).toHaveValue("Example");
+			expect(screen.getByLabelText("Retailer 1 label")).toHaveValue("Example");
 		});
 
 		it("should call onAddRetailerEntry when Add Retailer is clicked", async () => {
@@ -270,7 +270,7 @@ describe("ProductFormDialog", () => {
 				/>,
 			);
 
-			await user.type(screen.getByTestId("retailer-url-0"), "h");
+			await user.type(screen.getByLabelText("Retailer 1 URL"), "h");
 
 			expect(onUpdateRetailerEntry).toHaveBeenCalledWith(0, {
 				id: 1,
@@ -291,7 +291,9 @@ describe("ProductFormDialog", () => {
 				/>,
 			);
 
-			const removeButton = screen.getByTestId("retailer-remove-0");
+			const removeButton = screen.getByRole("button", {
+				name: "Remove retailer 1",
+			});
 			await user.click(removeButton);
 
 			expect(onRemoveRetailerEntry).toHaveBeenCalledWith(0);

--- a/apps/desktop/src/__tests__/unit/components/product-form-dialog.test.tsx
+++ b/apps/desktop/src/__tests__/unit/components/product-form-dialog.test.tsx
@@ -192,4 +192,109 @@ describe("ProductFormDialog", () => {
 			);
 		});
 	});
+
+	describe("retailers section (create mode)", () => {
+		const createModeProps = {
+			...defaultProps,
+			retailerEntries: [] as { id: number; url: string; label: string }[],
+			onAddRetailerEntry: vi.fn(),
+			onUpdateRetailerEntry: vi.fn(),
+			onRemoveRetailerEntry: vi.fn(),
+		};
+
+		it("should render Retailers label and Add Retailer button in create mode", () => {
+			render(<ProductFormDialog {...createModeProps} />);
+
+			expect(screen.getByText("Retailers")).toBeInTheDocument();
+			expect(
+				screen.getByRole("button", { name: /add retailer/i }),
+			).toBeInTheDocument();
+		});
+
+		it("should NOT render retailers section in edit mode", () => {
+			render(<ProductFormDialog {...createModeProps} mode="edit" />);
+
+			expect(screen.queryByText("Retailers")).not.toBeInTheDocument();
+			expect(
+				screen.queryByRole("button", { name: /add retailer/i }),
+			).not.toBeInTheDocument();
+		});
+
+		it("should show empty state message when no entries", () => {
+			render(<ProductFormDialog {...createModeProps} />);
+
+			expect(
+				screen.getByText(
+					"No retailers added. You can add retailers after creation too.",
+				),
+			).toBeInTheDocument();
+		});
+
+		it("should render retailer URL and label inputs when entries provided", () => {
+			render(
+				<ProductFormDialog
+					{...createModeProps}
+					retailerEntries={[
+						{ id: 1, url: "https://example.com", label: "Example" },
+					]}
+				/>,
+			);
+
+			expect(screen.getByTestId("retailer-url-0")).toHaveValue(
+				"https://example.com",
+			);
+			expect(screen.getByTestId("retailer-label-0")).toHaveValue("Example");
+		});
+
+		it("should call onAddRetailerEntry when Add Retailer is clicked", async () => {
+			const onAddRetailerEntry = vi.fn();
+			const { user } = render(
+				<ProductFormDialog
+					{...createModeProps}
+					onAddRetailerEntry={onAddRetailerEntry}
+				/>,
+			);
+
+			await user.click(screen.getByRole("button", { name: /add retailer/i }));
+
+			expect(onAddRetailerEntry).toHaveBeenCalledTimes(1);
+		});
+
+		it("should call onUpdateRetailerEntry with correct index on URL change", async () => {
+			const onUpdateRetailerEntry = vi.fn();
+			const { user } = render(
+				<ProductFormDialog
+					{...createModeProps}
+					retailerEntries={[{ id: 1, url: "", label: "" }]}
+					onUpdateRetailerEntry={onUpdateRetailerEntry}
+				/>,
+			);
+
+			await user.type(screen.getByTestId("retailer-url-0"), "h");
+
+			expect(onUpdateRetailerEntry).toHaveBeenCalledWith(0, {
+				id: 1,
+				url: "h",
+				label: "",
+			});
+		});
+
+		it("should call onRemoveRetailerEntry with correct index on remove click", async () => {
+			const onRemoveRetailerEntry = vi.fn();
+			const { user } = render(
+				<ProductFormDialog
+					{...createModeProps}
+					retailerEntries={[
+						{ id: 1, url: "https://example.com", label: "Example" },
+					]}
+					onRemoveRetailerEntry={onRemoveRetailerEntry}
+				/>,
+			);
+
+			const removeButton = screen.getByTestId("retailer-remove-0");
+			await user.click(removeButton);
+
+			expect(onRemoveRetailerEntry).toHaveBeenCalledWith(0);
+		});
+	});
 });

--- a/apps/desktop/src/modules/products/hooks/useProductDialogs.ts
+++ b/apps/desktop/src/modules/products/hooks/useProductDialogs.ts
@@ -84,39 +84,41 @@ export function useProductDialogs() {
 	};
 
 	const updateFormData = (formData: CreateProductInput) => {
-		if (dialogState.type === "create") {
-			setDialogState({ ...dialogState, formData });
-		} else if (dialogState.type === "edit") {
-			setDialogState({ ...dialogState, formData });
-		}
+		setDialogState((prev) => {
+			if (prev.type === "create" || prev.type === "edit") {
+				return { ...prev, formData };
+			}
+			return prev;
+		});
 	};
 
 	const addRetailerEntry = () => {
-		if (dialogState.type !== "create") return;
 		const id = nextEntryId.current++;
-		setDialogState({
-			...dialogState,
-			retailerEntries: [
-				...dialogState.retailerEntries,
-				{ id, url: "", label: "" },
-			],
+		setDialogState((prev) => {
+			if (prev.type !== "create") return prev;
+			return {
+				...prev,
+				retailerEntries: [...prev.retailerEntries, { id, url: "", label: "" }],
+			};
 		});
 	};
 
 	const updateRetailerEntry = (index: number, entry: RetailerEntry) => {
-		if (dialogState.type !== "create") return;
-		const updated = [...dialogState.retailerEntries];
-		updated[index] = entry;
-		setDialogState({ ...dialogState, retailerEntries: updated });
+		setDialogState((prev) => {
+			if (prev.type !== "create") return prev;
+			const updated = [...prev.retailerEntries];
+			updated[index] = entry;
+			return { ...prev, retailerEntries: updated };
+		});
 	};
 
 	const removeRetailerEntry = (index: number) => {
-		if (dialogState.type !== "create") return;
-		setDialogState({
-			...dialogState,
-			retailerEntries: dialogState.retailerEntries.filter(
-				(_, i) => i !== index,
-			),
+		setDialogState((prev) => {
+			if (prev.type !== "create") return prev;
+			return {
+				...prev,
+				retailerEntries: prev.retailerEntries.filter((_, i) => i !== index),
+			};
 		});
 	};
 

--- a/apps/desktop/src/modules/products/ui/components/product-form-dialog.tsx
+++ b/apps/desktop/src/modules/products/ui/components/product-form-dialog.tsx
@@ -126,6 +126,7 @@ export function ProductFormDialog({
 										<div key={entry.id} className="flex items-center gap-2">
 											<Input
 												data-testid={`retailer-url-${index}`}
+												aria-label={`Retailer ${index + 1} URL`}
 												value={entry.url}
 												onChange={(e) =>
 													onUpdateRetailerEntry?.(index, {
@@ -137,6 +138,7 @@ export function ProductFormDialog({
 											/>
 											<Input
 												data-testid={`retailer-label-${index}`}
+												aria-label={`Retailer ${index + 1} label`}
 												value={entry.label}
 												onChange={(e) =>
 													onUpdateRetailerEntry?.(index, {
@@ -151,6 +153,7 @@ export function ProductFormDialog({
 												variant="ghost"
 												size="icon-sm"
 												data-testid={`retailer-remove-${index}`}
+												aria-label={`Remove retailer ${index + 1}`}
 												onClick={() => onRemoveRetailerEntry?.(index)}
 											>
 												<Trash2 />

--- a/apps/desktop/src/modules/products/ui/components/product-form-dialog.tsx
+++ b/apps/desktop/src/modules/products/ui/components/product-form-dialog.tsx
@@ -1,3 +1,4 @@
+import { Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -10,6 +11,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import type { RetailerEntry } from "@/modules/products/hooks/useProductDialogs";
 import type { CreateProductInput } from "@/modules/products/hooks/useProducts";
 
 const MODE_CONFIG = {
@@ -35,6 +37,10 @@ interface ProductFormDialogProps {
 	onFormChange: (data: CreateProductInput) => void;
 	onSubmit: () => void;
 	isSubmitting: boolean;
+	retailerEntries?: RetailerEntry[];
+	onAddRetailerEntry?: () => void;
+	onUpdateRetailerEntry?: (index: number, entry: RetailerEntry) => void;
+	onRemoveRetailerEntry?: (index: number) => void;
 }
 
 export function ProductFormDialog({
@@ -45,6 +51,10 @@ export function ProductFormDialog({
 	onFormChange,
 	onSubmit,
 	isSubmitting,
+	retailerEntries,
+	onAddRetailerEntry,
+	onUpdateRetailerEntry,
+	onRemoveRetailerEntry,
 }: ProductFormDialogProps) {
 	const { title, description, submitLabel, submittingLabel } =
 		MODE_CONFIG[mode];
@@ -92,6 +102,65 @@ export function ProductFormDialog({
 							placeholder="Optional notes"
 						/>
 					</div>
+					{mode === "create" && retailerEntries && (
+						<div className="grid gap-2">
+							<div className="flex items-center justify-between">
+								<Label>Retailers</Label>
+								<Button
+									type="button"
+									variant="outline"
+									size="xs"
+									onClick={onAddRetailerEntry}
+								>
+									<Plus />
+									Add Retailer
+								</Button>
+							</div>
+							{retailerEntries.length === 0 ? (
+								<p className="text-muted-foreground text-sm">
+									No retailers added. You can add retailers after creation too.
+								</p>
+							) : (
+								<div className="grid gap-2">
+									{retailerEntries.map((entry, index) => (
+										<div key={entry.id} className="flex items-center gap-2">
+											<Input
+												data-testid={`retailer-url-${index}`}
+												value={entry.url}
+												onChange={(e) =>
+													onUpdateRetailerEntry?.(index, {
+														...entry,
+														url: e.target.value,
+													})
+												}
+												placeholder="https://example.com/product"
+											/>
+											<Input
+												data-testid={`retailer-label-${index}`}
+												value={entry.label}
+												onChange={(e) =>
+													onUpdateRetailerEntry?.(index, {
+														...entry,
+														label: e.target.value,
+													})
+												}
+												placeholder="Label (optional)"
+											/>
+											<Button
+												type="button"
+												variant="ghost"
+												size="icon-sm"
+												data-testid={`retailer-remove-${index}`}
+												onClick={() => onRemoveRetailerEntry?.(index)}
+											>
+												<Trash2 />
+											</Button>
+										</div>
+									))}
+								</div>
+							)}
+						</div>
+					)}
 				</div>
 				<DialogFooter>
 					<Button variant="outline" onClick={() => onOpenChange(false)}>


### PR DESCRIPTION
## Summary
- Allow users to add retailer URLs directly when creating a product, instead of requiring navigation to the product detail view
- Retailers section appears only in create mode with Add/Remove entry support and per-entry error handling
- Empty-URL entries are skipped; failed retailer adds show a toast but don't block product creation

## Test plan
- [x] Unit tests for `ProductFormDialog` retailers section (7 new tests)
- [x] Unit tests for `ProductsView` create-with-retailers flow (5 new tests)
- [x] All 571 frontend tests pass
- [x] All 105 Rust tests pass
- [x] Biome lint/format passes
- [x] TypeScript type check passes
- [ ] Manual test: open "Add Product" dialog, add 1-2 retailer URLs, create product, verify retailers appear in product detail view

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Product creation now supports adding multiple retailers (URL + label) inline; entries can be added, edited, or removed. Retailer submission is performed after product creation and per-entry failures do not block the overall create flow. UI shows retailer-specific submitting state.
* **Tests**
  * Added unit tests covering retailer UI in the create dialog, create-product flows with retailers, validation for empty URLs, and per-retailer error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->