### PR TITLE
fix(scraper): extract price from typeless Schema.org JSON-LD (bonds.c…

### DIFF
--- a/apps/desktop/src-tauri/crates/domain/src/services/scraper/price_parser.rs
+++ b/apps/desktop/src-tauri/crates/domain/src/services/scraper/price_parser.rs
@@ -132,6 +132,30 @@ pub fn has_path_locale(url: &str) -> bool {
     infer_currency_from_path(url).is_some()
 }
 
+/// Read a price-like field from an offer as a string, accepting either a JSON
+/// string or number. Returns `None` for any other type or a missing field.
+fn read_price_field(offer: &serde_json::Value, key: &str) -> Option<String> {
+    offer.get(key).and_then(|p| match p {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        _ => None,
+    })
+}
+
+/// Whether a raw price string represents zero (e.g. "0", "0.00", "$0").
+///
+/// Used to skip placeholder `price: 0` values on aggregate offers so we can fall
+/// back to `lowPrice`/`highPrice`.
+fn is_zero_price(price_str: &str) -> bool {
+    let cleaned: String = price_str
+        .chars()
+        .filter(|c| c.is_ascii_digit() || *c == '.')
+        .collect();
+    Decimal::from_str(&cleaned)
+        .map(|d| d.is_zero())
+        .unwrap_or(false)
+}
+
 /// Extract price info from an offer object
 ///
 /// Currency is determined in order of precedence:
@@ -140,11 +164,13 @@ pub fn has_path_locale(url: &str) -> bool {
 /// 3. Inferred from the store's domain TLD (e.g., .com.au → AUD) - weakest heuristic
 /// 4. None if none of the above are available
 pub fn get_price_from_offer(offer: &serde_json::Value, url: &str) -> PriceInfo {
-    let raw_price = offer.get("price").and_then(|p| match p {
-        serde_json::Value::String(s) => Some(s.clone()),
-        serde_json::Value::Number(n) => Some(n.to_string()),
-        _ => None,
-    });
+    // Prefer `price`, but fall back to an AggregateOffer's `lowPrice`/`highPrice`
+    // when `price` is absent or zero. Magento storefronts (e.g. bonds.com.au) emit
+    // a group-level offer with `price: 0` and the real value only in `lowPrice`.
+    let raw_price = read_price_field(offer, "price")
+        .filter(|p| !is_zero_price(p))
+        .or_else(|| read_price_field(offer, "lowPrice"))
+        .or_else(|| read_price_field(offer, "highPrice"));
 
     let api_currency = offer
         .get("priceCurrency")
@@ -287,6 +313,46 @@ mod tests {
         assert_eq!(price.price_minor_units, None);
         assert_eq!(price.price_currency, None);
         assert_eq!(price.raw_price, None);
+    }
+
+    #[test]
+    fn test_get_price_from_offer_zero_price_falls_back_to_low_price() {
+        // Magento aggregate offer: `price` is a placeholder 0; the real value
+        // lives in `lowPrice` (this is the bonds.com.au shape).
+        let offer = serde_json::json!({
+            "availability": "https://schema.org/InStock",
+            "price": 0,
+            "priceCurrency": "AUD",
+            "lowPrice": 30,
+            "highPrice": 30
+        });
+        let price = get_price_from_offer(&offer, "https://www.bonds.com.au/x.html");
+        assert_eq!(price.price_minor_units, Some(3000));
+        assert_eq!(price.price_currency, Some("AUD".to_string()));
+    }
+
+    #[test]
+    fn test_get_price_from_offer_only_low_price() {
+        let offer = serde_json::json!({
+            "priceCurrency": "USD",
+            "lowPrice": "19.99"
+        });
+        let price = get_price_from_offer(&offer, "https://store.com/x");
+        assert_eq!(price.price_minor_units, Some(1999));
+        assert_eq!(price.price_currency, Some("USD".to_string()));
+    }
+
+    #[test]
+    fn test_get_price_from_offer_high_price_when_low_absent() {
+        // `price` is the string "0.00" (also zero) and there is no `lowPrice`,
+        // so `highPrice` is used.
+        let offer = serde_json::json!({
+            "price": "0.00",
+            "priceCurrency": "USD",
+            "highPrice": 25
+        });
+        let price = get_price_from_offer(&offer, "https://store.com/x");
+        assert_eq!(price.price_minor_units, Some(2500));
     }
 
     #[test]

--- a/apps/desktop/src-tauri/crates/domain/src/services/scraper/schema_org.rs
+++ b/apps/desktop/src-tauri/crates/domain/src/services/scraper/schema_org.rs
@@ -107,14 +107,44 @@ fn has_schema_type(json: &serde_json::Value, expected_type: &str) -> bool {
     }
 }
 
-/// Check if a JSON value represents a Product type
-fn is_product_type(json: &serde_json::Value) -> bool {
-    has_schema_type(json, "Product")
+/// Whether a JSON object lacks a usable `@type` field.
+///
+/// Some storefronts (notably Magento, e.g. bonds.com.au) emit Product/ProductGroup
+/// JSON-LD with no `@type` at all. When `@type` is missing we fall back to
+/// structural detection based on the fields that are present.
+fn lacks_type(json: &serde_json::Value) -> bool {
+    match json.get("@type") {
+        None | Some(serde_json::Value::Null) => true,
+        Some(serde_json::Value::String(s)) => s.is_empty(),
+        Some(serde_json::Value::Array(arr)) => arr.is_empty(),
+        _ => false,
+    }
 }
 
-/// Check if a JSON value represents a ProductGroup type
+/// Whether the JSON object carries a non-empty `hasVariant` array.
+fn has_variants(json: &serde_json::Value) -> bool {
+    json.get("hasVariant")
+        .and_then(|v| v.as_array())
+        .is_some_and(|arr| !arr.is_empty())
+}
+
+/// Check if a JSON value represents a Product type.
+///
+/// Matches an explicit `@type: "Product"`, or — when `@type` is absent — a block
+/// that carries `offers` but no variants (a single product, not a group). The
+/// "no variants" guard ensures a typeless ProductGroup is not misread as a
+/// Product (which would consume its aggregate offer instead of a variant).
+fn is_product_type(json: &serde_json::Value) -> bool {
+    has_schema_type(json, "Product")
+        || (lacks_type(json) && json.get("offers").is_some() && !has_variants(json))
+}
+
+/// Check if a JSON value represents a ProductGroup type.
+///
+/// Matches an explicit `@type: "ProductGroup"`, or — when `@type` is absent — a
+/// block that carries a non-empty `hasVariant` array.
 fn is_product_group_type(json: &serde_json::Value) -> bool {
-    has_schema_type(json, "ProductGroup")
+    has_schema_type(json, "ProductGroup") || (lacks_type(json) && has_variants(json))
 }
 
 /// Get availability and price from a ProductGroup by matching variant ID
@@ -351,5 +381,123 @@ mod tests {
         // Should use first offer's availability
         assert_eq!(avail, "http://schema.org/OutOfStock");
         assert_eq!(price.price_minor_units, Some(4999));
+    }
+
+    #[test]
+    fn test_extract_typeless_product_group_bonds() {
+        // bonds.com.au (Magento) emits a ProductGroup with NO `@type`. Detection
+        // must fall back to the `hasVariant` structure. The aggregate offer has
+        // price 0, so the resolved price comes from the first variant.
+        let json = serde_json::json!({
+            "sku": "AVMJI_PCL",
+            "brand": { "@type": "Brand", "name": "Bonds" },
+            "offers": {
+                "availability": "https://schema.org/InStock",
+                "itemCondition": "https://schema.org/NewCondition",
+                "price": 0,
+                "priceCurrency": "AUD",
+                "offerCount": 2,
+                "lowPrice": 30,
+                "highPrice": 30
+            },
+            "productGroupID": "AVMJI_PCL",
+            "variesBy": ["https://schema.org/size"],
+            "hasVariant": [
+                {
+                    "sku": "AVMJI_PCL-XXL",
+                    "size": "XXL",
+                    "brand": { "@type": "Brand" },
+                    "offers": {
+                        "availability": "https://schema.org/InStock",
+                        "itemCondition": "https://schema.org/NewCondition",
+                        "price": 30,
+                        "priceCurrency": "AUD"
+                    }
+                },
+                {
+                    "sku": "AVMJI_PCL-3XL",
+                    "size": "3XL",
+                    "brand": { "@type": "Brand" },
+                    "offers": {
+                        "availability": "https://schema.org/InStock",
+                        "itemCondition": "https://schema.org/NewCondition",
+                        "price": 30,
+                        "priceCurrency": "AUD"
+                    }
+                }
+            ]
+        });
+
+        let result = extract_availability_and_price(
+            &json,
+            None,
+            "https://www.bonds.com.au/originals-skinny-trackie-avmji-pcl.html",
+        );
+        assert!(result.is_some());
+        let (avail, price) = result.unwrap();
+        assert_eq!(avail, "https://schema.org/InStock");
+        assert_eq!(price.price_minor_units, Some(3000));
+        assert_eq!(price.price_currency, Some("AUD".to_string()));
+    }
+
+    #[test]
+    fn test_extract_typeless_single_product() {
+        // A single product with `offers` but no `@type` and no variants should
+        // route through the Product branch.
+        let json = serde_json::json!({
+            "sku": "SKU123",
+            "offers": {
+                "availability": "https://schema.org/InStock",
+                "price": 49.99,
+                "priceCurrency": "AUD"
+            }
+        });
+        let result = extract_availability_and_price(&json, None, "https://store.com.au/products/x");
+        assert!(result.is_some());
+        let (avail, price) = result.unwrap();
+        assert_eq!(avail, "https://schema.org/InStock");
+        assert_eq!(price.price_minor_units, Some(4999));
+    }
+
+    #[test]
+    fn test_typeless_block_without_offers_or_variants_is_ignored() {
+        // A typeless block that is neither a product nor a group (e.g. an
+        // Organization-like blob) must not be misclassified.
+        let json = serde_json::json!({
+            "name": "Bonds Australia",
+            "url": "https://www.bonds.com.au/"
+        });
+        let result = extract_availability_and_price(&json, None, "https://www.bonds.com.au/");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_typed_product_group_with_aggregate_uses_variant_price() {
+        // Regression guard: an explicit ProductGroup carrying an aggregate
+        // `offers` (price 0) must still resolve to a variant price, not the
+        // aggregate. Confirms the structural Product fallback does not hijack
+        // typed ProductGroups.
+        let json = serde_json::json!({
+            "@type": "ProductGroup",
+            "offers": {
+                "availability": "https://schema.org/InStock",
+                "price": 0,
+                "priceCurrency": "AUD"
+            },
+            "hasVariant": [
+                {
+                    "@type": "Product",
+                    "offers": {
+                        "availability": "https://schema.org/InStock",
+                        "price": 30,
+                        "priceCurrency": "AUD"
+                    }
+                }
+            ]
+        });
+        let result = extract_availability_and_price(&json, None, "https://store.com.au/x");
+        assert!(result.is_some());
+        let (_, price) = result.unwrap();
+        assert_eq!(price.price_minor_units, Some(3000));
     }
 }


### PR DESCRIPTION
…om.au)

Magento storefronts like bonds.com.au emit Product/ProductGroup JSON-LD with no `@type` field, and a group-level aggregate offer whose `price` is 0 (the real value lives in `lowPrice`/`highPrice` and per-variant offers).

The scraper dispatched purely on `@type`, so these blocks matched neither the Product nor ProductGroup branch and extraction returned no price.

- schema_org: detect Product/ProductGroup structurally when `@type` is absent (hasVariant -> group; offers and no variants -> product).
- price_parser: fall back to lowPrice/highPrice when price is missing or 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved product price detection to correctly handle zero/placeholder prices and intelligently fall back to price ranges when available on various storefronts.
  * Enhanced product classification to properly distinguish between individual products and product groups, reducing misclassification of items from storefronts using alternative or minimal data formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/reuel88/product-stalker/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->